### PR TITLE
Added additional information to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,21 @@ public class EditAccountController {
 	//...... more members of your controller class.......
 
 public EditAccountController(ApexPages.StandardController controller) {
+
+// Create list of fields to add to controller for object 
+ List<String> fields = new List<String>{'Id', 'AccountNumber', 'AccountSource', 'Active__c', 'AnnualRevenue', 'BillingAddress', 'BillingCity', 'BillingCountry',
+                                          'BillingGeocodeAccuracy', 'BillingLatitude', 'BillingLongitude', 'BillingPostalCode', 'BillingState', 'BillingStreet',
+                                          'CleanStatus', 'CreatedById', 'CreatedDate', 'custom_field__c', 'CustomerPriority__c',
+                                          'DandbCompanyId', 'Description', 'DunsNumber', 'Fax', 'Industry', 'IsDeleted', 'Jigsaw', 'JigsawCompanyId', 'LastActivityDate',
+                                          'LastModifiedById', 'LastModifiedDate', 'LastReferencedDate', 'LastViewedDate', 'MasterRecordId', 'NaicsCode', 'NaicsDesc', 'Name', 'NumberOfEmployees',
+                                          'NumberofLocations__c', 'OwnerId', 'Ownership', 'ParentId', 'Phone', 'PhotoUrl', 'Rating', 'ShippingAddress', 'ShippingCity', 'ShippingCountry', 'ShippingGeocodeAccuracy',
+                                          'ShippingLatitude', 'ShippingLongitude', 'ShippingPostalCode', 'ShippingState', 'ShippingStreet', 'Sic', 'SicDesc', 'Site',
+                                          'SLA__c', 'SLAExpirationDate__c', 'SLASerialNumber__c', 'SystemModstamp', 'test1__c', 'test__c', 'TEST_TIMEOUT__c',
+                                          'testField123__c', 'testField1__c', 'testField__c', 'TickerSymbol', 'Tradestyle', 'Type', 'UpsellOpportunity__c', 'Website', 'YearStarted', 'OwnerId'};
+
+// Add fields to controller. This is to avoid the SOQL error in visualforce page
+controller.addFields(fields);
+
 sObject obj = controller.getRecord();
 
 //.... more code to do things

--- a/README.md
+++ b/README.md
@@ -39,15 +39,15 @@ public class EditAccountController {
 public EditAccountController(ApexPages.StandardController controller) {
 
 // Create list of fields to add to controller for object 
- List<String> fields = new List<String>{'Id', 'AccountNumber', 'AccountSource', 'Active__c', 'AnnualRevenue', 'BillingAddress', 'BillingCity', 'BillingCountry',
-                                          'BillingGeocodeAccuracy', 'BillingLatitude', 'BillingLongitude', 'BillingPostalCode', 'BillingState', 'BillingStreet',
-                                          'CleanStatus', 'CreatedById', 'CreatedDate', 'custom_field__c', 'CustomerPriority__c',
-                                          'DandbCompanyId', 'Description', 'DunsNumber', 'Fax', 'Industry', 'IsDeleted', 'Jigsaw', 'JigsawCompanyId', 'LastActivityDate',
-                                          'LastModifiedById', 'LastModifiedDate', 'LastReferencedDate', 'LastViewedDate', 'MasterRecordId', 'NaicsCode', 'NaicsDesc', 'Name', 'NumberOfEmployees',
-                                          'NumberofLocations__c', 'OwnerId', 'Ownership', 'ParentId', 'Phone', 'PhotoUrl', 'Rating', 'ShippingAddress', 'ShippingCity', 'ShippingCountry', 'ShippingGeocodeAccuracy',
-                                          'ShippingLatitude', 'ShippingLongitude', 'ShippingPostalCode', 'ShippingState', 'ShippingStreet', 'Sic', 'SicDesc', 'Site',
-                                          'SLA__c', 'SLAExpirationDate__c', 'SLASerialNumber__c', 'SystemModstamp', 'test1__c', 'test__c', 'TEST_TIMEOUT__c',
-                                          'testField123__c', 'testField1__c', 'testField__c', 'TickerSymbol', 'Tradestyle', 'Type', 'UpsellOpportunity__c', 'Website', 'YearStarted', 'OwnerId'};
+List<String> fields = new List<String>{'Id', 'AccountNumber', 'AccountSource', 'AnnualRevenue', 'BillingAddress', 'BillingCity', 'BillingCountry',
+									  'BillingGeocodeAccuracy', 'BillingLatitude', 'BillingLongitude', 'BillingPostalCode', 'BillingState', 'BillingStreet',
+									  'CleanStatus', 'CreatedById', 'CreatedDate', 'DandbCompanyId', 'Description', 'DunsNumber', 'Fax', 'Industry', 'IsDeleted',
+									  'Jigsaw', 'JigsawCompanyId', 'LastActivityDate', 'LastModifiedById', 'LastModifiedDate', 'LastReferencedDate', 'LastViewedDate',
+									  'MasterRecordId', 'NaicsCode', 'NaicsDesc', 'Name', 'NumberOfEmployees', 'OwnerId', 'Ownership', 'ParentId', 'Phone', 'PhotoUrl',
+									  'Rating', 'ShippingAddress', 'ShippingCity', 'ShippingCountry', 'ShippingGeocodeAccuracy', 'ShippingLatitude', 'ShippingLongitude',
+									  'ShippingPostalCode', 'ShippingState', 'ShippingStreet', 'Sic', 'SicDesc', 'Site', 'SystemModstamp', 'TickerSymbol', 'Tradestyle',
+									  'Type', 'Website', 'YearStarted', 'OwnerId'};
+controller.addFields(fields);
 
 // Add fields to controller. This is to avoid the SOQL error in visualforce page
 controller.addFields(fields);


### PR DESCRIPTION
Adding additional example of how to add fields to the controller to avoid the Visualforce error.

I spent a good amount of time trying to figure out what the following phrase meant:

> Make sure you select the fields of the object before referencing them otherwise you'll get an annoying sfdc standard error.

Eventually I looked up the standard controller and found this method.  It would have saved me a lot of time to have known exactly what to do instead of hunting this down.